### PR TITLE
Integrate tRPC and React Query for categories

### DIFF
--- a/multi-vendor-ecom/bun.lock
+++ b/multi-vendor-ecom/bun.lock
@@ -35,7 +35,12 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@tanstack/react-query": "5.72.1",
+        "@trpc/client": "11.0.3",
+        "@trpc/server": "11.0.3",
+        "@trpc/tanstack-react-query": "11.0.3",
         "class-variance-authority": "^0.7.1",
+        "client-only": "0.0.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
@@ -52,10 +57,12 @@
         "react-hook-form": "^7.59.0",
         "react-resizable-panels": "^3.0.3",
         "recharts": "^3.0.2",
+        "server-only": "0.0.1",
         "sonner": "^2.0.5",
+        "superjson": "^2.2.2",
         "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2",
-        "zod": "^3.25.67",
+        "zod": "3.24.2",
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -718,7 +725,17 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.11", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.11", "@tailwindcss/oxide": "4.1.11", "postcss": "^8.4.41", "tailwindcss": "4.1.11" } }, "sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA=="],
 
+    "@tanstack/query-core": ["@tanstack/query-core@5.72.1", "", {}, "sha512-nOu0EEkZuJ0BZnYgeaEfo44+psq1jBO7/zp3KudixD4dvgOVerrhAhDEKsWx2N7MxB59mjO4r0ddP/VqWGPK+Q=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.72.1", "", { "dependencies": { "@tanstack/query-core": "5.72.1" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-4UEMyRx54xj144D2nDvDIMiXSG5BrqyCJrmyNoGbymNS+VWODcBDFrmRk9p2fe12UGZ4JtKPTNuW2Jg0aisUgQ=="],
+
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@trpc/client": ["@trpc/client@11.0.3", "", { "peerDependencies": { "@trpc/server": "11.0.3", "typescript": ">=5.7.2" } }, "sha512-nUhRo/Ml3LQzs2USs5pfquNqETEQOMS6o9IR30cwn32oj4NuXXSqe9UqUc3hIBALtVzcfg6mLK43hGQA9O3X/Q=="],
+
+    "@trpc/server": ["@trpc/server@11.0.3", "", { "peerDependencies": { "typescript": ">=5.7.2" } }, "sha512-/qlaFITZ5a9OCI5mZiW94C8q9mr/wxCmb8GfP3k7VF9RuY4ql+M1UWrzS7xAj8bHekqG9PcR8qEWlOJ6NnXbQg=="],
+
+    "@trpc/tanstack-react-query": ["@trpc/tanstack-react-query@11.0.3", "", { "peerDependencies": { "@tanstack/react-query": "^5.67.1", "@trpc/client": "11.0.3", "@trpc/server": "11.0.3", "react": ">=18.2.0", "react-dom": ">=18.2.0", "typescript": ">=5.7.2" } }, "sha512-4U3oagLmWBQ1nxbfyvQInImWHoIGx8AQcSaB+wrynFN8u+VAk2AvYNXpSolsdbmkTH1IJlofp+NlsvU4kPW7wA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw=="],
 
@@ -965,6 +982,8 @@
     "console-table-printer": ["console-table-printer@2.12.1", "", { "dependencies": { "simple-wcswidth": "^1.0.1" } }, "sha512-wKGOQRRvdnd89pCeH96e2Fn4wkbenSP6LMHfjfyNLMbGuHEFbMqQNuxXqd0oXG9caIOQ1FTvc5Uijp9/4jujnQ=="],
 
     "convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+
+    "copy-anything": ["copy-anything@3.0.5", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w=="],
 
     "cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
@@ -1311,6 +1330,8 @@
     "is-weakref": ["is-weakref@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew=="],
 
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
+
+    "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
@@ -1690,6 +1711,8 @@
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
+
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
@@ -1767,6 +1790,8 @@
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "stylis": ["stylis@4.2.0", "", {}, "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="],
+
+    "superjson": ["superjson@2.2.2", "", { "dependencies": { "copy-anything": "^3.0.2" } }, "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1896,7 +1921,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.67", "", {}, "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="],
+    "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/multi-vendor-ecom/package.json
+++ b/multi-vendor-ecom/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "db:fresh":"payload migrate:fresh",
-    "db:seed":"bun run src/seed.ts"    
+    "db:fresh": "payload migrate:fresh",
+    "db:seed": "bun run src/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -42,7 +42,12 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@tanstack/react-query": "5.72.1",
+    "@trpc/client": "11.0.3",
+    "@trpc/server": "11.0.3",
+    "@trpc/tanstack-react-query": "11.0.3",
     "class-variance-authority": "^0.7.1",
+    "client-only": "0.0.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
@@ -59,10 +64,12 @@
     "react-hook-form": "^7.59.0",
     "react-resizable-panels": "^3.0.3",
     "recharts": "^3.0.2",
+    "server-only": "0.0.1",
     "sonner": "^2.0.5",
+    "superjson": "^2.2.2",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^3.25.67"
+    "zod": "3.24.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/multi-vendor-ecom/src/app/(app)/(home)/layout.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/layout.tsx
@@ -1,34 +1,24 @@
-import configPromise from '@payload-config';
-import { getPayload } from 'payload';
+import { HydrateClient, prefetch, trpc } from '@/trpc/server';
 import Footer from "./footer";
 import Navbar from "./Navbar";
-import { SearchFilter } from "./search-filters";
+import SearchFilterLoading, { SearchFilter } from "./search-filters";
+import { Suspense } from 'react';
+import { useTRPC } from '@/trpc/client';
+
 
 interface Props {
     children: React.ReactNode;
 }
 
-const Layout = async ({ children }: Props) => {
-    const payload = await getPayload({
-        config: configPromise
-    });
-
-    const data = await payload.find({
-        collection: 'categories',
-        depth: 1,
-        pagination: false,
-        where: {
-            parent: {
-                exists: false
-            }
-        },
-        sort:"name"
-    });   
-
+const Layout = async ({ children }: Props) => {   
     return (
         <div className="flex flex-col min-h-screen">
             <Navbar />
-            <SearchFilter data={data} />
+            <HydrateClient>
+                <Suspense fallback={<SearchFilterLoading />}>
+                    <SearchFilter />
+                </Suspense>
+            </HydrateClient>
             <div className="flex-1 bg-[#f4f4f0]">
                 {children}
             </div>

--- a/multi-vendor-ecom/src/app/(app)/(home)/page.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/page.tsx
@@ -1,4 +1,9 @@
-export default async function Home() {
+"use client";
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/trpc/client';
+
+export default function Home() {
+
   return (
     <div>
       Home Page

--- a/multi-vendor-ecom/src/app/(app)/(home)/search-filters/Categories.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/search-filters/Categories.tsx
@@ -1,14 +1,14 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { CustomCategory } from "../types";
 import { CategoryDropDown } from "./category-drop-down";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ListFilterIcon } from "lucide-react";
 import { CategoriesSidebar } from "./categories-sidebar";
+import { CategoriesGetManyOutput } from "@/modules/categories/types";
 
 interface CategoriesProps {
-    data: CustomCategory[];
+    data: CategoriesGetManyOutput;
 }
 
 export const Categories = ({ data }: CategoriesProps) => {
@@ -48,7 +48,7 @@ export const Categories = ({ data }: CategoriesProps) => {
     return (
         <div className="relative w-full ">
             {/* category side bar */}
-            <CategoriesSidebar open={isSidebarOpen} onOpenChange={setIsSidebarOpen} data={data}/>
+            <CategoriesSidebar open={isSidebarOpen} onOpenChange={setIsSidebarOpen}/>
             {/* calculation purpose */}
             <div className="absolute opacity-0 pointer-events-none flex"
                 ref={measureRef}

--- a/multi-vendor-ecom/src/app/(app)/(home)/search-filters/categories-sidebar.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/search-filters/categories-sidebar.tsx
@@ -1,21 +1,22 @@
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { useState } from "react";
-import { CustomCategory } from "../types";
 import { ScrollArea } from "@radix-ui/react-scroll-area";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
-
+import { useTRPC } from "@/trpc/client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { CategoriesGetManyOutput } from "@/modules/categories/types";
 
 interface CategorySidebarProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    data: CustomCategory[]; // remove later if not needed
 }
 
-export const CategoriesSidebar = ({ open, onOpenChange, data }: CategorySidebarProps) => {
-    const [parentCategory, setParentCategory] = useState<CustomCategory[] | null>(null);
-    const [activeCategory, setActiveCategory] = useState<CustomCategory | null>(null);
-    // if we have 
+export const CategoriesSidebar = ({ open, onOpenChange }: CategorySidebarProps) => {
+    const trpc = useTRPC();
+    const { data } = useSuspenseQuery(trpc.categories.getMany.queryOptions());
+    const [parentCategory, setParentCategory] = useState<CategoriesGetManyOutput[] | null>(null);
+    const [activeCategory, setActiveCategory] = useState<CategoriesGetManyOutput[1] | null>(null);
     const currentCategory = parentCategory ?? data ?? [];
     const router = useRouter();
     const backgroundColor = activeCategory ? activeCategory.color : "whitesmoke";

--- a/multi-vendor-ecom/src/app/(app)/(home)/search-filters/category-drop-down.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/search-filters/category-drop-down.tsx
@@ -1,15 +1,14 @@
 "use client";
-
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useRef, useState } from 'react';
 import { useDropdownPosition } from './use-drodown-position';
 import { SubCategoryMenu } from './sub-category-menu';
-import { CustomCategory } from '../types';
 import Link from 'next/link';
+import { CategoriesGetManyOutput } from '@/modules/categories/types';
 
 interface CategoryDDProps {
-    category: CustomCategory;
+    category: CategoriesGetManyOutput[1];
     isActive?: boolean;
     isNavigationHovered?: boolean;
 }
@@ -17,7 +16,7 @@ interface CategoryDDProps {
 export const CategoryDropDown = ({ category, isActive, isNavigationHovered }: CategoryDDProps) => {
 
     const [isOpen, isSetOpen] = useState(false);
-    const dropDownRef = useRef<HTMLDivElement>(null);
+    const dropDownRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;;
     const { getDropdownPosition } = useDropdownPosition(dropDownRef);
 
     const onMouseEnter = () => {

--- a/multi-vendor-ecom/src/app/(app)/(home)/search-filters/index.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/search-filters/index.tsx
@@ -1,26 +1,27 @@
-import { Category } from '@/payload-types';
+"use client";
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Categories } from "./Categories";
 import { SearchInput } from "./search-input";
-import { CustomCategory } from '../types';
+import { useTRPC } from '@/trpc/client';
 
-
-interface SearchFilterProps {    
-    data: CustomCategory[];
-}
-
-export const SearchFilter = ({ data }: SearchFilterProps) => {
-
-    const formattedData: CustomCategory[] = data.docs.map((doc: { subcategories: { docs: unknown; }; }) => ({
-        ...doc,
-        subcategories: (doc?.subcategories?.docs ?? []).map((doc: Category) => ({
-            ...(doc as Category)
-        }))
-    }));
-
+export const SearchFilter = () => {
+    const trpc = useTRPC();
+    const { data } = useSuspenseQuery(trpc.categories.getMany.queryOptions());
     return (
-        <div className="px-4 lg:px-12 py-8 border-b flex flex-col gap-4 w-full">
-            <SearchInput data={data} />            
-            <Categories data={formattedData} />
+        <div className="px-4 lg:px-12 py-8 border-b flex flex-col gap-4 w-full" style={{ backgroundColor: '#F5F5F5' }}>
+            <SearchInput />
+            <Categories data={data} />
         </div>
     );
 };
+
+const SearchFilterLoading = () => {
+    return (
+        <div className="px-4 lg:px-12 py-8 border-b flex flex-col gap-4 w-full" style={{ backgroundColor: '#F5F5F5' }}>
+            <SearchInput disabled />
+            <div className='h-12' />
+        </div>
+    );
+};
+
+export default SearchFilterLoading;

--- a/multi-vendor-ecom/src/app/(app)/(home)/search-filters/search-input.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/search-filters/search-input.tsx
@@ -1,14 +1,11 @@
 import { Input } from "@/components/ui/input";
 import { SearchIcon } from "lucide-react";
-import { CustomCategory } from "../types";
-
 
 interface SearchInputProps {
-    disabled?: boolean;
-    data: CustomCategory[];
+    disabled?: boolean;   
 }
 
-export const SearchInput = ({ disabled, data }: SearchInputProps) => {
+export const SearchInput = ({ disabled }: SearchInputProps) => {
     //  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
     return (
         <div className="flex items-center gap-2 w-full">

--- a/multi-vendor-ecom/src/app/(app)/(home)/search-filters/sub-category-menu.tsx
+++ b/multi-vendor-ecom/src/app/(app)/(home)/search-filters/sub-category-menu.tsx
@@ -1,9 +1,15 @@
-import { Category } from '@/payload-types';
+// import { Category } from '@/payload-types';
+// Define Category type locally if not exported from '@/payload-types'
+type Category = {
+    slug: string;
+    name: string;
+    // Add other properties if needed
+};
 import Link from 'next/link';
-import { CustomCategory } from '../types';
+import { CategoriesGetManyOutput } from '@/modules/categories/types';
 
 interface SubCategoryMenuProps {
-    category: CustomCategory;
+    category: CategoriesGetManyOutput[1];
     isOpen: boolean;
     position: { top: number, left: number; };
 }
@@ -26,8 +32,7 @@ export const SubCategoryMenu = ({
              bg-amber-50' style={{ borderRadius: "10px " }}>
                 <div>
                     {category.subcategories?.map((subCat: Category) => (
-                        <Link key={subCat.slug} 
-                            href={`/${category.slug}/${subCat.slug}`}
+                        <Link key={subCat.slug} href='/'
                             className='w-full text-left p-4 border-b-2 border-black hover:bg-gray-300  hover:text-black hover:border-r-6 hover:border-green-600 hover:underline flex justify-between  items-center font-medium'
                             style={{ borderRadius: "10px " }}>
                             {subCat.name}

--- a/multi-vendor-ecom/src/app/(app)/(home)/types.ts
+++ b/multi-vendor-ecom/src/app/(app)/(home)/types.ts
@@ -1,6 +1,6 @@
-import {Category} from "@/payload-types"
+// import {Category} from "@/payload-types"
 
-export type CustomCategory = Category & {
-    subcategories : Category[],
+// export type CustomCategory = Category & {
+//     subcategories : Category[],
     
-}
+// }

--- a/multi-vendor-ecom/src/app/(app)/api/trpc/[trpc]/route.ts
+++ b/multi-vendor-ecom/src/app/(app)/api/trpc/[trpc]/route.ts
@@ -1,0 +1,11 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { createTRPCContext } from '@/trpc/init';
+import { appRouter } from '@/trpc/routers/_app';
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: createTRPCContext,
+  });
+export { handler as GET, handler as POST };

--- a/multi-vendor-ecom/src/app/(app)/layout.tsx
+++ b/multi-vendor-ecom/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { TRPCProvider, TRPCReactProvider } from "@/trpc/client";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <TRPCReactProvider>
+            {children}
+        </TRPCReactProvider>
+        
       </body>
     </html>
   );

--- a/multi-vendor-ecom/src/modules/categories/server/procedures.ts
+++ b/multi-vendor-ecom/src/modules/categories/server/procedures.ts
@@ -1,0 +1,31 @@
+import { Category } from '@/payload-types';
+import { baseProcedure, createTRPCRouter } from "@/trpc/init";
+
+export const CategoriesRouter = createTRPCRouter({
+    getMany: baseProcedure.query(async ({ ctx }) => {
+        const data = await ctx.db.find({
+            collection: 'categories',
+            depth: 1,
+            pagination: false,
+            where: {
+                parent: {
+                    exists: false
+                }
+            },
+            sort: "name"
+        });
+
+        const formattedData = data.docs.map((doc) => {
+            const categoryDoc = doc as Category;
+            return {
+                ...categoryDoc,
+                subcategories: (categoryDoc.subcategories?.docs ?? []).map((subDoc: Category) => ({
+                    ...subDoc,
+                    subcategories: undefined // Ensure subcategories are undefined if not present
+                }))
+            };
+        });
+
+        return formattedData;
+    })
+});

--- a/multi-vendor-ecom/src/modules/categories/types.ts
+++ b/multi-vendor-ecom/src/modules/categories/types.ts
@@ -1,0 +1,4 @@
+import { inferRouterOutputs } from "@trpc/server";
+import { AppRouter } from "@/trpc/routers/_app";
+export type CategoriesGetManyOutput = inferRouterOutputs<AppRouter>['categories']['getMany'];
+export type CategoriesGetManyOutputSingle = CategoriesGetManyOutput[number];

--- a/multi-vendor-ecom/src/trpc/client.tsx
+++ b/multi-vendor-ecom/src/trpc/client.tsx
@@ -1,0 +1,58 @@
+'use client';
+// ^-- to make sure we can mount the Provider from a server component
+import type { QueryClient } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCContext } from '@trpc/tanstack-react-query';
+import { useState } from 'react';
+import { makeQueryClient } from './query-client';
+import type { AppRouter } from './routers/_app';
+export const { TRPCProvider, useTRPC } = createTRPCContext<AppRouter>();
+let browserQueryClient: QueryClient;
+function getQueryClient() {
+    if (typeof window === 'undefined') {
+        // Server: always make a new query client
+        return makeQueryClient();
+    }
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+}
+function getUrl() {
+    const base = (() => {
+        if (typeof window !== 'undefined') return '';
+        return process.env.NEXT_PUBLIC_APP_URL;
+    })();
+    return `${base}/api/trpc`;
+}
+export function TRPCReactProvider(
+    props: Readonly<{
+        children: React.ReactNode;
+    }>,
+) {
+    // NOTE: Avoid useState when initializing the query client if you don't
+    //       have a suspense boundary between this and the code that may
+    //       suspend because React will throw away the client on the initial
+    //       render if it suspends and there is no boundary
+    const queryClient = getQueryClient();
+    const [trpcClient] = useState(() =>
+        createTRPCClient<AppRouter>({
+            links: [
+                httpBatchLink({
+                    // transformer: superjson, <-- if you use a data transformer
+                    url: getUrl(),
+                }),
+            ],
+        }),
+    );
+    return (
+        <QueryClientProvider client={queryClient}>
+            <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+                {props.children}
+            </TRPCProvider>
+        </QueryClientProvider>
+    );
+}

--- a/multi-vendor-ecom/src/trpc/init.ts
+++ b/multi-vendor-ecom/src/trpc/init.ts
@@ -1,0 +1,30 @@
+import { initTRPC } from '@trpc/server';
+import next from 'next';
+import { getPayload } from 'payload';
+import { cache } from 'react';
+import config from '@payload-config';
+export const createTRPCContext = cache(async () => {
+    /**
+     * @see: https://trpc.io/docs/server/context
+     */
+    return { userId: 'user_123' };
+});
+// Avoid exporting the entire t-object
+// since it's not very descriptive.
+// For instance, the use of a t variable
+// is common in i18n libraries.
+const t = initTRPC.create({
+    /**
+     * @see https://trpc.io/docs/server/data-transformers
+     */
+    // transformer: superjson,
+});
+// Base router and procedure helpers
+export const createTRPCRouter = t.router;
+export const createCallerFactory = t.createCallerFactory;
+export const baseProcedure = t.procedure.use(async ({ next }) => {
+    const payload = await getPayload({ config });
+    return next({
+        ctx: { db: payload }
+    });
+});

--- a/multi-vendor-ecom/src/trpc/query-client.ts
+++ b/multi-vendor-ecom/src/trpc/query-client.ts
@@ -1,0 +1,23 @@
+import {
+    defaultShouldDehydrateQuery,
+    QueryClient,
+} from '@tanstack/react-query';
+// import superjson from 'superjson';
+export function makeQueryClient() {
+    return new QueryClient({
+        defaultOptions: {
+            queries: {
+                staleTime: 30 * 1000,
+            },
+            dehydrate: {
+                // serializeData: superjson.serialize,
+                shouldDehydrateQuery: (query) =>
+                    defaultShouldDehydrateQuery(query) ||
+                    query.state.status === 'pending',
+            },
+            hydrate: {
+                // deserializeData: superjson.deserialize,
+            },
+        },
+    });
+}

--- a/multi-vendor-ecom/src/trpc/routers/_app.ts
+++ b/multi-vendor-ecom/src/trpc/routers/_app.ts
@@ -1,0 +1,7 @@
+import { createTRPCRouter } from '../init';
+import { CategoriesRouter } from '@/modules/categories/server/procedures';
+export const appRouter = createTRPCRouter({
+   categories:CategoriesRouter
+});
+// export type definition of API
+export type AppRouter = typeof appRouter;

--- a/multi-vendor-ecom/src/trpc/server.tsx
+++ b/multi-vendor-ecom/src/trpc/server.tsx
@@ -1,0 +1,35 @@
+import 'server-only'; // <-- ensure this file cannot be imported from the client
+import { createTRPCOptionsProxy, TRPCQueryOptions } from '@trpc/tanstack-react-query';
+import { cache } from 'react';
+import { createTRPCContext } from './init';
+import { makeQueryClient } from './query-client';
+import { appRouter } from './routers/_app';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+// IMPORTANT: Create a stable getter for the query client that
+//            will return the same client during the same request.
+export const getQueryClient = cache(makeQueryClient);
+export const trpc = createTRPCOptionsProxy({
+    ctx: createTRPCContext,
+    router: appRouter,
+    queryClient: getQueryClient,
+});
+
+export function HydrateClient(props: { children: React.ReactNode; }) {
+    const queryClient = getQueryClient();
+    return (
+        <HydrationBoundary state={dehydrate(queryClient)}>
+            {props.children}
+        </HydrationBoundary>
+    );
+}
+
+export function prefetch<T extends ReturnType<TRPCQueryOptions<any>>>(
+    queryOptions: T,
+) {
+    const queryClient = getQueryClient();
+    if (queryOptions.queryKey[1]?.type === 'infinite') {
+        void queryClient.prefetchInfiniteQuery(queryOptions as any);
+    } else {
+        void queryClient.prefetchQuery(queryOptions);
+    }
+}


### PR DESCRIPTION
Refactored category data fetching to use tRPC and React Query, replacing direct Payload CMS calls. Added tRPC server/client setup, query client, and types for categories. Updated search filter and related components to use new data flow. Added API route and procedures for categories, and wrapped app in TRPCReactProvider for context.